### PR TITLE
Set Recreate Deployment for Milvus writable node (#79)

### DIFF
--- a/templates/writable-deployment.yaml
+++ b/templates/writable-deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     component: "writable"
 spec:
   replicas: {{ .Values.replicas }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}


### PR DESCRIPTION
Signed-off-by: quicksilver <zhifeng.zhang@zilliz.com>

Set Recreate Deployment for Milvus writable node. fix #79 