### PR TITLE
Fix "wrong number of args for printf: want at least 1 got 0"

### DIFF
--- a/templates/readonly-deployment.yaml
+++ b/templates/readonly-deployment.yaml
@@ -126,7 +126,7 @@ spec:
       - name: milvus-logs-disk
         {{- if .Values.logsPersistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.logsPersistence.persistentVolumeClaim.existingClaim | default printf "%s-logs" (include "milvus.fullname" . | trunc 58) }}
+          claimName: {{ .Values.logsPersistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
         {{- else }}
         emptyDir: {}
         {{- end }}

--- a/templates/writable-deployment.yaml
+++ b/templates/writable-deployment.yaml
@@ -127,7 +127,7 @@ spec:
       - name: milvus-logs-disk
         {{- if .Values.logsPersistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.logsPersistence.persistentVolumeClaim.existingClaim | default printf "%s-logs" (include "milvus.fullname" . | trunc 58) }}
+          claimName: {{ .Values.logsPersistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
         {{- else }}
         emptyDir: {}
         {{- end }}


### PR DESCRIPTION
If I hava `conf.yaml`. 
```
$ cat conf.yaml
persistence:
  enabled: true
  persistentVolumeClaim:
    existingClaim: "milvus-data"

logsPersistence:
  enabled: true
  persistentVolumeClaim:
    existingClaim: "milvus-log"
$ helm install --dry-run --name=milvus -f conf.yaml ./milvus-helm
```
It will report the follow error:
```
Error: render error in "milvus/templates/writable-deployment.yaml": template: milvus/templates/writable-deployment.yaml:128:94: executing "milvus/templates/writable-deployment.yaml" at <printf>: wrong number of args for printf: want at least 1 got 0
```.