### PR TITLE
Fixed syntax error when neither mysql nor externalMysql is enabled

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "0.10.3"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open source similarity search engine for massive-scalefeature vectors.
-version: 0.10.3
+version: 0.10.4
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/readonly-deployment.yaml
+++ b/charts/milvus/templates/readonly-deployment.yaml
@@ -22,9 +22,10 @@ spec:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
+{{- if or .Values.mysql.enabled .Values.externalMysql.enabled .Values.cluster.enabled }}
     spec:
-      {{- if or .Values.mysql.enabled .Values.externalMysql.enabled }}
       initContainers:
+      {{- if or .Values.mysql.enabled .Values.externalMysql.enabled }}
       - name: "wait-for-mysql"
         image: {{ .Values.initContainerImage | quote }}
         command:
@@ -59,6 +60,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+{{- end }}
 {{- if .Values.extraInitContainers }}
 {{ toYaml .Values.extraInitContainers | indent 6 }}
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:
When neither mysql nor externalMysql is enabled, a syntax error is produced. This fixes it.