### PR TITLE
Fixed specify readonly resources doesn't take effect bug

### DIFF
--- a/charts/milvus/templates/readonly-deployment.yaml
+++ b/charts/milvus/templates/readonly-deployment.yaml
@@ -85,7 +85,7 @@ spec:
             port: 19530
 {{ toYaml .Values.readinessProbe | indent 10 }}
         resources:
-          {{- toYaml .Values.image.resources | nindent 10 }}
+          {{- toYaml .Values.readonly.resources | nindent 10 }}
         volumeMounts:
         - name: milvus-data-disk
           mountPath: {{ .Values.persistence.mountPath | quote }}


### PR DESCRIPTION
Signed-off-by: quicksilver <zhifeng.zhang@zilliz.com>

## What this PR does / why we need it:
Fixed specify readonly resources doesn't take effect bug #123 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
