### PR TITLE
Fix ClusterRole resource conflict bug

### DIFF
--- a/charts/milvus/templates/mishards-rbac.yaml
+++ b/charts/milvus/templates/mishards-rbac.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: pods-list
+  name: {{ template "milvus.fullname" . }}-pods-list
 rules:
 - apiGroups: [""]
   resources: ["pods", "events"]
@@ -13,7 +13,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: pods-list
+  name: {{ template "milvus.fullname" . }}-pods-list
 subjects:
 - kind: ServiceAccount
   name: default


### PR DESCRIPTION
Signed-off-by: quicksilver <zhifeng.zhang@zilliz.com>

## What this PR does / why we need it:
Fix ClusterRole resource conflict bug

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
