### PR TITLE
Disable check readonly node ready status when readonly replicas is 0

### DIFF
--- a/charts/milvus/templates/nginx-deployment.yaml
+++ b/charts/milvus/templates/nginx-deployment.yaml
@@ -32,7 +32,9 @@ spec:
           {{- else }}
           until nc -z -w 2 {{ .Release.Name }}-mysql 3306
           {{- end }}
+          {{- if not (eq 0 (int .Values.readonly.replicas)) }}
           && nc -z -w 2 {{ template "milvus.readonly.fullname" . }} {{ .Values.service.port }}
+          {{- else }}
           && nc -z -w 2 {{ template "milvus.writable.fullname" . }} {{ .Values.service.port }}
           && echo ready to go; do
             sleep 2;

--- a/charts/milvus/templates/nginx-deployment.yaml
+++ b/charts/milvus/templates/nginx-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           {{- end }}
           {{- if not (eq 0 (int .Values.readonly.replicas)) }}
           && nc -z -w 2 {{ template "milvus.readonly.fullname" . }} {{ .Values.service.port }}
-          {{- else }}
+          {{- end }}
           && nc -z -w 2 {{ template "milvus.writable.fullname" . }} {{ .Values.service.port }}
           && echo ready to go; do
             sleep 2;


### PR DESCRIPTION
## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
