### PR TITLE
Comment out the access_log parameter in Nginx configuration file

### DIFF
--- a/charts/milvus/templates/_nginx_config.tpl
+++ b/charts/milvus/templates/_nginx_config.tpl
@@ -15,7 +15,7 @@ http {
     }
     {{- end }}
 
-    access_log  /var/log/nginx/access.log;
+    # access_log  /var/log/nginx/access.log;
 
     server {
         listen {{ .Values.service.port }} http2;


### PR DESCRIPTION
Signed-off-by: quicksilver <zhifeng.zhang@zilliz.com>

## What this PR does / why we need it:
Comment out the access_log parameter in Nginx configuration file

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
