### PR TITLE
Define liveness and readiness probes uses an HTTP GET request

### DIFF
--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -94,7 +94,6 @@ The following table lists the configurable parameters of the Milvus chart and th
 | `logs.logRotateNum`                       | The maximum number of log files that Milvus keeps for each logging level, num range [0, 1024], 0 means unlimited. | `0` |
 | `cache.insertBufferSize`                  | Maximum insert buffer size allowed (GB)       | `1GB`                                                   |
 | `cache.cacheSize`                         | Size of CPU memory used for cache  (GB)       | `4GB`                                                   |
-| `network.httpEnabled`                     | Enable web server or not.                     | `true`                                                  |
 | `network.httpPort`                        | Port that Milvus web server monitors.         | `19121`                                                 |
 | `wal.enabled`                             | Enable write-ahead logging.                   | `true`                                                  |
 | `wal.recoveryErrorIgnore`                 | Whether to ignore logs with errors that happens during WAL | `true`                                     |

--- a/charts/milvus/templates/NOTES.txt
+++ b/charts/milvus/templates/NOTES.txt
@@ -5,33 +5,22 @@ Get the Milvus server URL by running these commands in the same shell:
 {{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "milvus.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-{{- if .Values.network.httpEnabled }}
   export WEB_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "milvus.fullname" . }})
   echo $NODE_IP:$NODE_PORT $NODE_IP:$WEB_NODE_PORT
-{{- else }}
-  echo $NODE_IP:$NODE_PORT
-{{- end }}
 {{- else if contains "LoadBalancer" .Values.service.type }}
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "milvus.fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "milvus.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  {{- if .Values.network.httpEnabled }}
   echo $SERVICE_IP:{{ .Values.service.port }} $SERVICE_IP:{{ .Values.network.httpPort }}
-  {{- else }}
-  echo $SERVICE_IP:{{ .Values.service.port }}
-  {{- end }}
+
 {{- else if contains "ClusterIP"  .Values.service.type }}
 {{- if .Values.cluster.enabled }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "milvus.name" . }},app.kubernetes.io/instance={{ .Release.Name }},component=nginx" -o jsonpath="{.items[0].metadata.name}")
 {{- else }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "milvus.name" . }},app.kubernetes.io/instance={{ .Release.Name }},component=writable" -o jsonpath="{.items[0].metadata.name}")
 {{- end }}
-{{- if .Values.network.httpEnabled }}
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 19530 19121
-{{- else }}
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 19530
-{{- end }}
 {{- end }}
 
 {{- if .Values.admin.enabled }}

--- a/charts/milvus/templates/_readonly_server_config.tpl
+++ b/charts/milvus/templates/_readonly_server_config.tpl
@@ -57,7 +57,7 @@ general:
 network: 
   bind.address: 0.0.0.0
   bind.port: 19530
-  http.enable: false
+  http.enable: true
   http.port: 19121
 
 #----------------------+------------------------------------------------------------+------------+-----------------+

--- a/charts/milvus/templates/_server_config.tpl
+++ b/charts/milvus/templates/_server_config.tpl
@@ -57,7 +57,7 @@ general:
 network: 
   bind.address: 0.0.0.0
   bind.port: 19530
-  http.enable: {{ .Values.network.httpEnabled }}
+  http.enable: true
   http.port: 19121
 
 #----------------------+------------------------------------------------------------+------------+-----------------+

--- a/charts/milvus/templates/readonly-deployment.yaml
+++ b/charts/milvus/templates/readonly-deployment.yaml
@@ -77,12 +77,16 @@ spec:
             containerPort: 19121
             protocol: TCP
         livenessProbe:
-          tcpSocket:
-            port: 19530
+          httpGet:
+            path: system/status
+            port: 19121
+            scheme: HTTP
 {{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:
-          tcpSocket:
-            port: 19530
+          httpGet:
+            path: system/status
+            port: 19121
+            scheme: HTTP
 {{ toYaml .Values.readinessProbe | indent 10 }}
         resources:
           {{- toYaml .Values.readonly.resources | nindent 10 }}

--- a/charts/milvus/templates/readonly-svc.yaml
+++ b/charts/milvus/templates/readonly-svc.yaml
@@ -22,7 +22,6 @@ spec:
 {{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{.Values.service.nodePort}}
 {{ end }}
-    {{- if .Values.network.httpEnabled }}
     - name: web
       port: {{ .Values.network.httpPort }}
       protocol: TCP
@@ -30,7 +29,6 @@ spec:
 {{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.webNodePort))) }}
       nodePort: {{.Values.service.webNodePort}}
 {{ end }}
-    {{- end }}
   selector:
 {{ include "milvus.matchLabels" . | indent 4 }}
     component: "readonly"

--- a/charts/milvus/templates/writable-deployment.yaml
+++ b/charts/milvus/templates/writable-deployment.yaml
@@ -82,12 +82,16 @@ spec:
             containerPort: 19121
             protocol: TCP
         livenessProbe:
-          tcpSocket:
-            port: 19530
+          httpGet:
+            path: system/status
+            port: 19121
+            scheme: HTTP
 {{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:
-          tcpSocket:
-            port: 19530
+          httpGet:
+            path: system/status
+            port: 19121
+            scheme: HTTP
 {{ toYaml .Values.readinessProbe | indent 10 }}
         resources:
           {{- toYaml .Values.image.resources | nindent 10 }}

--- a/charts/milvus/templates/writable-svc.yaml
+++ b/charts/milvus/templates/writable-svc.yaml
@@ -53,7 +53,6 @@ spec:
 {{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)) (not .Values.cluster.enabled)) }}
       nodePort: {{.Values.service.nodePort}}
 {{ end }}
-    {{- if .Values.network.httpEnabled }}
     - name: web
       port: {{ .Values.network.httpPort }}
       protocol: TCP
@@ -61,7 +60,6 @@ spec:
 {{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.webNodePort)) (not .Values.cluster.enabled)) }}
       nodePort: {{.Values.service.webNodePort}}
 {{ end }}
-    {{- end }}
   selector:
 {{ include "milvus.matchLabels" . | indent 4 }}
     component: "writable"

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -19,7 +19,6 @@ cache:
   cacheSize: 4GB
 
 network:
-  httpEnabled: true
   httpPort: 19121
 
 storage:


### PR DESCRIPTION
Signed-off-by: quicksilver <zhifeng.zhang@zilliz.com>

## What this PR does / why we need it:
Define liveness and readiness probes uses an HTTP GET request

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
