### PR TITLE
improvment: mysql connection string for sqlalchemy.

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "1.1.0"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open source similarity search engine for massive-scalefeature vectors.
-version: 1.1.0
+version: 1.1.1
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/_helpers.tpl
+++ b/charts/milvus/templates/_helpers.tpl
@@ -90,12 +90,21 @@ Create the name of the service account to use for the mishards component
 {{- end -}}
 {{- end -}}
 
+
 {{/* Milvus backend URL */}}
 {{- define "milvus.mysqlURI" -}}
 {{- if .Values.externalMysql.enabled -}}
 mysql://{{ .Values.externalMysql.user }}:{{ .Values.externalMysql.password }}@{{ .Values.externalMysql.ip }}:{{ .Values.externalMysql.port }}/{{ .Values.externalMysql.database }}
 {{- else -}}
 mysql://root:{{ .Values.mysql.mysqlRootPassword }}@{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.mysqlDatabase }}
+{{- end -}}
+{{- end -}}
+
+{{- define "milvus.mysqlURISqlalchemy" -}}
+{{- if .Values.externalMysql.enabled -}}
+mysql+pymysql://{{ .Values.externalMysql.user }}:{{ .Values.externalMysql.password }}@{{ .Values.externalMysql.ip }}:{{ .Values.externalMysql.port }}/{{ .Values.externalMysql.database }}
+{{- else -}}
+mysql+pymysql://root:{{ .Values.mysql.mysqlRootPassword }}@{{ .Release.Name }}-mysql:3306/{{ .Values.mysql.mysqlDatabase }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/milvus/templates/_mishards_config.tpl
+++ b/charts/milvus/templates/_mishards_config.tpl
@@ -3,7 +3,7 @@
 MAX_WORKERS={{ .Values.mishards.maxWorkers }}
 
 {{- if or .Values.mysql.enabled .Values.externalMysql.enabled }}
-SQLALCHEMY_DATABASE_URI={{ template "milvus.mysqlURI" . }}
+SQLALCHEMY_DATABASE_URI={{ template "milvus.mysqlURISqlalchemy" . }}
 {{- else }}
 SQLALCHEMY_DATABASE_URI={{ template "milvus.sqliteURI" . }}
 {{- end }}

--- a/charts/milvus/templates/mishards-deployment.yaml
+++ b/charts/milvus/templates/mishards-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - 'sh'
         - '-c'
         - >
-            pip install mysqlclient && python mishards/main.py
+          python mishards/main.py
         ports:
           - name: mishards
             containerPort: 19530


### PR DESCRIPTION
Using mysql+pymysql: scheme for SQLALCHEMY_DATABASE_URI.

## What this PR does / why we need it:
mishards already have installed `PyMySQL`, so using `mysql+pymysql://` as a connection scheme is enough, we could remove install `mysqlclient` during the container's startup.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
