### PR TITLE
Fix for YAML parse error in writable-deployment when mysql and externalMysql are disabled

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "1.1.0"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open source similarity search engine for massive-scalefeature vectors.
-version: 1.1.1
+version: 1.1.2
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/writable-deployment.yaml
+++ b/charts/milvus/templates/writable-deployment.yaml
@@ -27,8 +27,8 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      {{- if or .Values.mysql.enabled .Values.externalMysql.enabled }}
       initContainers:
+      {{- if or .Values.mysql.enabled .Values.externalMysql.enabled }}
       - name: "wait-for-mysql"
         image: {{ .Values.initContainerImage | quote }}
         command:


### PR DESCRIPTION
## What this PR does / why we need it:
This PR fixes:
```
Error: YAML parse error on milvus/templates/writable-deployment.yaml: error converting YAML to JSON: yaml: line 43: did not find expected '-' indicator
```
when both `mysql` and `externalMysql` are disabled

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
