### PR TITLE
Fix the link for Milvus logo in Chart.yaml

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "1.1.0"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open source similarity search engine for massive-scalefeature vectors.
-version: 1.1.2
+version: 1.1.3
 keywords:
   - milvus
   - elastic
@@ -11,7 +11,7 @@ keywords:
   - search
   - deploy
 home: https://milvus.io/
-icon: https://raw.githubusercontent.com/milvus-io/docs/master/assets/milvus_logo.png
+icon: https://raw.githubusercontent.com/milvus-io/docs/master/v1.0.0/assets/milvus_logo.png
 sources:
   - https://github.com/milvus-io/milvus
   - https://github.com/milvus-io/milvus-helm


### PR DESCRIPTION
Signed-off-by: quicksilver <zhifeng.zhang@zilliz.com>

## What this PR does / why we need it:
Fix the link for Milvus logo in Chart.yaml

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
