### PR TITLE
HorizontalPodAutoscaler support

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.0-rc.1"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 2.0.4
+version: 2.0.5
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -149,6 +149,7 @@ The following table lists the configurable parameters of the Milvus Proxy compon
 | `proxy.affinity`                          | Affinity settings for Milvus Proxy pods assignment | `{}`                                               |
 | `proxy.tolerations`                       | Toleration labels for Milvus Proxy pods assignment | `[]`                                               |
 | `proxy.extraEnv`                          | Additional Milvus Proxy container environment variables | `[]`                                          |
+| `proxy.autoscaling.*`                     | Configs for the HorizontalPodAutoscaler of the Proxy Pods | `<see values.yaml>`                         |
 
 ### Milvus Root Coordinator Deployment Configuration
 
@@ -207,6 +208,7 @@ The following table lists the configurable parameters of the Milvus Query Node c
 | `queryNode.affinity`                      | Affinity settings for Milvus Query Node pods assignment | `{}`                                          |
 | `queryNode.tolerations`                   | Toleration labels for Milvus Query Node pods assignment | `[]`                                          |
 | `queryNode.extraEnv`                      | Additional Milvus Query Node container environment variables | `[]`                                     |
+| `queryNode.autoscaling.*`                 | Configs for the HorizontalPodAutoscaler of the Query Node Pods | `<see values.yaml>`                    |
 
 ### Milvus Index Coordinator Deployment Configuration
 
@@ -243,6 +245,7 @@ The following table lists the configurable parameters of the Milvus Index Node c
 | `indexNode.affinity`                      | Affinity settings for Milvus Index Node pods assignment | `{}`                                          |
 | `indexNode.tolerations`                   | Toleration labels for Milvus Index Node pods assignment | `[]`                                          |
 | `indexNode.extraEnv`                      | Additional Milvus Index Node container environment variables | `[]`                                     |
+| `indexNode.autoscaling.*`                 | Configs for the HorizontalPodAutoscaler of the Index Node Pods | `<see values.yaml>`                    |
 
 ### Milvus Data Coordinator Deployment Configuration
 
@@ -279,6 +282,7 @@ The following table lists the configurable parameters of the Milvus Data Node co
 | `dataNode.affinity`                       | Affinity settings for Milvus Data Node pods assignment | `{}`                                           |
 | `dataNode.tolerations`                    | Toleration labels for Milvus Data Node pods assignment | `[]`                                           |
 | `dataNode.extraEnv`                       | Additional Milvus Data Node container environment variables | `[]`                                      |
+| `dataNode.autoscaling.*`                  | Configs for the HorizontalPodAutoscaler of the Data Node Pods | `<see values.yaml>`                     |
 
 ### Pulsar Standalone Deployment Configuration
 

--- a/charts/milvus/templates/hpa.yaml
+++ b/charts/milvus/templates/hpa.yaml
@@ -1,0 +1,79 @@
+{{- if and (.Values.proxy.enabled) (.Values.proxy.autoscaling.enabled) }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "milvus.proxy.fullname" . }}
+  labels:
+    {{ include "milvus.labels" . | indent 4 }}
+    component: "proxy"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "milvus.proxy.fullname" . }}
+  minReplicas: {{ .Values.proxy.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.proxy.autoscaling.maxReplicas }}
+  metrics:
+{{ toYaml .Values.proxy.autoscaling.metrics | indent 4 }}
+{{- end }}
+
+{{- if and (.Values.queryNode.enabled) (.Values.queryNode.autoscaling.enabled) }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "milvus.querynode.fullname" . }}
+  labels:
+    {{ include "milvus.labels" . | indent 4 }}
+    component: "querynode"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "milvus.querynode.fullname" . }}
+  minReplicas: {{ .Values.queryNode.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.queryNode.autoscaling.maxReplicas }}
+  metrics:
+{{ toYaml .Values.queryNode.autoscaling.metrics | indent 4 }}
+{{- end }}
+
+{{- if and (.Values.indexNode.enabled) (.Values.indexNode.autoscaling.enabled) }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "milvus.indexnode.fullname" . }}
+  labels:
+    {{ include "milvus.labels" . | indent 4 }}
+    component: "indexnode"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "milvus.indexnode.fullname" . }}
+  minReplicas: {{ .Values.indexNode.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.indexNode.autoscaling.maxReplicas }}
+  metrics:
+{{ toYaml .Values.indexNode.autoscaling.metrics | indent 4 }}
+{{- end }}
+
+{{- if and (.Values.dataNode.enabled) (.Values.dataNode.autoscaling.enabled) }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "milvus.datanode.fullname" . }}
+  labels:
+    {{ include "milvus.labels" . | indent 4 }}
+    component: "datanode"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "milvus.datanode.fullname" . }}
+  minReplicas: {{ .Values.dataNode.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.dataNode.autoscaling.maxReplicas }}
+  metrics:
+{{ toYaml .Values.dataNode.autoscaling.metrics | indent 4 }}
+{{- end }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -108,6 +108,25 @@ proxy:
   tolerations: []
   extraEnv: []
 
+  # Enable autoscaling using HorizontalPodAutoscaler
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 60
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 60
+
 rootCoordinator:
   enabled: true
   replicas: 1  # Run Root Coordinator mode with replication disabled
@@ -147,6 +166,25 @@ queryNode:
   tolerations: []
   extraEnv: []
 
+  # Enable autoscaling using HorizontalPodAutoscaler
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 60
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 60
+
 indexCoordinator:
   enabled: true
   replicas: 1   # Run Index Coordinator mode with replication disabled
@@ -171,6 +209,25 @@ indexNode:
   tolerations: []
   extraEnv: []
 
+  # Enable autoscaling using HorizontalPodAutoscaler
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 60
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 60
+
 dataCoordinator:
   enabled: true
   replicas: 1           # Run Data Coordinator mode with replication disabled
@@ -194,6 +251,25 @@ dataNode:
   affinity: {}
   tolerations: []
   extraEnv: []
+
+  # Enable autoscaling using HorizontalPodAutoscaler
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 5
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 60
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 60
 
 pulsarStandalone:
   image:


### PR DESCRIPTION
Signed-off-by: quicksilver <zhifeng.zhang@zilliz.com>

## What this PR does / why we need it:
This feature supports the horizontal pod auto scaler for milvus

/cc @zwd1208 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
