### PR TITLE
Increase the default pulsar pvc storage to 100GB

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.0-rc.5-hotfix1"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 2.1.13
+version: 2.1.14
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -335,7 +335,7 @@ pulsarStandalone:
       ##
       storageClass:
       accessModes: ReadWriteOnce
-      size: 5Gi
+      size: 100Gi
       subPath: ""
 
 ## Configuration values for the minio dependency


### PR DESCRIPTION
## What this PR does / why we need it:
Increase the default pulsar pvc storage to 100GB.
/cc @zwd1208 
## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
