### PR TITLE
Set milvus standalone upgrade strategy to recreate

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.0-rc.5-hotfix1"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 2.1.14
+version: 2.1.15
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     component: "standalone"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
 {{ include "milvus.matchLabels" . | indent 6 }}


### PR DESCRIPTION
## What this PR does / why we need it:

Set milvus standalone upgrade strategy to `recreate`.
/cc @zwd1208 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
