### PR TITLE
Add minio Azure Blob Storage gateway support

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.0-rc.6"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 2.1.16
+version: 2.1.17
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -123,6 +123,7 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `externalS3.bucketName`                   | The Bucket Name of the external S3            | `unset`                                                 |
 | `externalS3.useSSL`                       | If true, use SSL to connect to the external S3 | `false`                                                |
 | `externalGcs.bucketName`                  | The Bucket Name of the external GCS. Requires GCS gateway to be enabled in the minIO configuration | `unset`                                                |
+| `externalAzure.bucketName`                  | The Bucket Name of the external Azure Blob Storage. Requires Azure gateway to be enabled in the minIO configuration | `unset`                                                |
 | `externalEtcd.enabled`                    | Enable or disable external Etcd               | `false`                                                 |
 | `externalEtcd.endpoints`                  | The endpoints of the external etcd            | `{}`                                                    |
 | `externalPulsar.enabled`                  | Enable or disable external Pulsar             | `false`                                                 |

--- a/charts/milvus/templates/config.tpl
+++ b/charts/milvus/templates/config.tpl
@@ -40,6 +40,8 @@ minio:
   useSSL: {{ .Values.minio.tls.enabled }}
 {{- if .Values.minio.gcsgateway.enabled }}
   bucketName: {{ .Values.externalGcs.bucketName }}
+{{- else if .Values.minio.azuregateway.enabled }}
+  bucketName: {{ .Values.externalAzure.bucketName }}
 {{- else }}
   bucketName: "milvus-bucket"
 {{- end }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -358,6 +358,10 @@ minio:
     gcsKeyJson: "/etc/credentials/gcs_key.json"
     projectId: ""
 
+  azuregateway:
+    enabled: false
+    replicas: 1
+
   service:
     type: ClusterIP
     port: 9000
@@ -481,6 +485,13 @@ externalS3:
 # - these configs are only used when `minio.gcsgateway.enabled` is true
 ###################################
 externalGcs:
+  bucketName: ""
+
+###################################
+# GCS Gateway
+# - these configs are only used when `minio.gcsgateway.enabled` is true
+###################################
+externalAzure:
   bucketName: ""
 
 ###################################


### PR DESCRIPTION
## What this PR does / why we need it:

Simple helm changes to add support for minIO's Azure Gateway mode in order to use Azure Blob Storage as storage. Azure Blob Storage is the Microsoft Azure equivalent of AWS S3. 

The Azure gateway node is an alternative running method for the MinIO Server which behaves the same from the client's perspective, but translates and forwards all connections to Azure with the according Azure connection API.

Metadata that must be set by user
- minio.azuregateway.enabled: Must be set to "true" to enable operation.
  -  Default is false. 
- minio.accessKey: Name of the Azure storage account to use.
- minio.secretKey: Access key for the Azure storage account.
- externalAzure.bucketName: Name of the Azure storage bucket to use. Unlike S3/MinIO buckets, Azure buckets must be globally unique. Therefore the default value is unset.
  - Default is unset.
Metadata that should be left as default
- minio.azuregateway.replicas: Number of replica nodes to use for the Azure gateway. We highly recommended you to only use one because MinIO does not have good support for higher numbers. 
  - Default is 1.
  - 
## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
