### PR TITLE
Add CACHE_SIZE env to milvus components deployments

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.0-rc.6"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 2.1.19
+version: 2.1.20
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -33,6 +33,11 @@ spec:
         args: [ "milvus", "run", "datacoord" ]
         {{- if .Values.dataCoordinator.extraEnv }}
         env:
+          - name: CACHE_SIZE
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+                divisor: 1Gi
           {{- toYaml .Values.dataCoordinator.extraEnv | nindent 10 }}
         {{- end }}
         ports:

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -33,6 +33,11 @@ spec:
         args: [ "milvus", "run", "datanode" ]
         {{- if .Values.dataNode.extraEnv }}
         env:
+          - name: CACHE_SIZE
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+                divisor: 1Gi
           {{- toYaml .Values.dataNode.extraEnv | nindent 10 }}
         {{- end }}
         ports:

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -33,6 +33,11 @@ spec:
         args: [ "milvus", "run", "indexcoord" ]
         {{- if .Values.indexCoordinator.extraEnv }}
         env:
+          - name: CACHE_SIZE
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+                divisor: 1Gi
           {{- toYaml .Values.indexCoordinator.extraEnv | nindent 10 }}
         {{- end }}
         ports:

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -33,6 +33,11 @@ spec:
         args: [ "milvus", "run", "indexnode" ]
         {{- if .Values.indexNode.extraEnv }}
         env:
+          - name: CACHE_SIZE
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+                divisor: 1Gi
           {{- toYaml .Values.indexNode.extraEnv | nindent 10 }}
         {{- end }}
         ports:

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -33,6 +33,11 @@ spec:
         args: [ "milvus", "run", "proxy" ]
         {{- if .Values.proxy.extraEnv }}
         env:
+          - name: CACHE_SIZE
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+                divisor: 1Gi
           {{- toYaml .Values.proxy.extraEnv | nindent 10 }}
         {{- end }}
         ports:

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -33,6 +33,11 @@ spec:
         args: [ "milvus", "run", "querycoord" ]
         {{- if .Values.queryCoordinator.extraEnv }}
         env:
+          - name: CACHE_SIZE
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+                divisor: 1Gi
           {{- toYaml .Values.queryCoordinator.extraEnv | nindent 10 }}
         {{- end }}
         ports:

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -33,6 +33,11 @@ spec:
         args: [ "milvus", "run", "querynode" ]
         {{- if .Values.queryNode.extraEnv }}
         env:
+          - name: CACHE_SIZE
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+                divisor: 1Gi
           {{- toYaml .Values.queryNode.extraEnv | nindent 10 }}
         {{- end }}
         ports:

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -33,6 +33,11 @@ spec:
         args: [ "milvus", "run", "rootcoord" ]
         {{- if .Values.rootCoordinator.extraEnv }}
         env:
+          - name: CACHE_SIZE
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+                divisor: 1Gi
           {{- toYaml .Values.rootCoordinator.extraEnv | nindent 10 }}
         {{- end }}
         ports:

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -35,6 +35,11 @@ spec:
         args: [ "milvus", "run", "standalone" ]
         {{- if .Values.standalone.extraEnv }}
         env:
+          - name: CACHE_SIZE
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+                divisor: 1Gi
           {{- toYaml .Values.standalone.extraEnv | nindent 10 }}
         {{- end }}
         ports:

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -105,12 +105,7 @@ standalone:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  extraEnv:
-  - name: CACHE_SIZE
-    valueFrom:
-      resourceFieldRef:
-        resource: limits.memory
-        divisor: 1Gi
+  extraEnv: []
 
   rocksmq:
     retentionTimeInMinutes: 10080
@@ -144,12 +139,7 @@ proxy:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  extraEnv:
-  - name: CACHE_SIZE
-    valueFrom:
-      resourceFieldRef:
-        resource: limits.memory
-        divisor: 1Gi
+  extraEnv: []
 
   # Enable autoscaling using HorizontalPodAutoscaler
   autoscaling:
@@ -177,12 +167,7 @@ rootCoordinator:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  extraEnv:
-  - name: CACHE_SIZE
-    valueFrom:
-      resourceFieldRef:
-        resource: limits.memory
-        divisor: 1Gi
+  extraEnv: []
 
   service:
     port: 53100
@@ -197,12 +182,7 @@ queryCoordinator:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  extraEnv:
-  - name: CACHE_SIZE
-    valueFrom:
-      resourceFieldRef:
-        resource: limits.memory
-        divisor: 1Gi
+  extraEnv: []
 
   service:
     port: 19531
@@ -217,12 +197,7 @@ queryNode:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  extraEnv:
-  - name: CACHE_SIZE
-    valueFrom:
-      resourceFieldRef:
-        resource: limits.memory
-        divisor: 1Gi
+  extraEnv: []
 
   # Enable autoscaling using HorizontalPodAutoscaler
   autoscaling:
@@ -250,12 +225,7 @@ indexCoordinator:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  extraEnv:
-  - name: CACHE_SIZE
-    valueFrom:
-      resourceFieldRef:
-        resource: limits.memory
-        divisor: 1Gi
+  extraEnv: []
 
   service:
     port: 31000
@@ -270,12 +240,7 @@ indexNode:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  extraEnv:
-  - name: CACHE_SIZE
-    valueFrom:
-      resourceFieldRef:
-        resource: limits.memory
-        divisor: 1Gi
+  extraEnv: []
 
   # Enable autoscaling using HorizontalPodAutoscaler
   autoscaling:
@@ -303,12 +268,7 @@ dataCoordinator:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  extraEnv:
-  - name: CACHE_SIZE
-    valueFrom:
-      resourceFieldRef:
-        resource: limits.memory
-        divisor: 1Gi
+  extraEnv: []
 
   service:
     port: 13333
@@ -323,12 +283,7 @@ dataNode:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  extraEnv:
-  - name: CACHE_SIZE
-    valueFrom:
-      resourceFieldRef:
-        resource: limits.memory
-        divisor: 1Gi
+  extraEnv: []
 
   # Enable autoscaling using HorizontalPodAutoscaler
   autoscaling:


### PR DESCRIPTION
Signed-off-by: jeffzzhang <jeffzzhang@tencent.com>

## What this PR does / why we need it:
Add CACHE_SIZE env to milvus components deployments

/cc @LoveEachDay @zwd1208 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
