### PR TITLE
fix for missing pahType in ingress definition and enables custom images for etcd and minio

### DIFF
--- a/charts/milvus/templates/ingress.yaml
+++ b/charts/milvus/templates/ingress.yaml
@@ -39,6 +39,7 @@ spec:
     http:
       paths:
         - path: /
+          pathType: Prefix
           backend:
             service:
               name: {{ $serviceName }}
@@ -83,6 +84,7 @@ spec:
     http:
       paths:
         - path: /
+          pathType: Prefix
           backend:
             serviceName: {{ $serviceName }}
             servicePort: {{ $servicePort }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -430,6 +430,7 @@ minio:
   name: minio
   mode: distributed
   image:
+    repository: minio/minio
     tag: "RELEASE.2020-11-06T23-17-07Z"
     pullPolicy: IfNotPresent
   accessKey: minioadmin
@@ -464,6 +465,7 @@ etcd:
   name: etcd
   replicaCount: 3
   image:
+    registry: "docker.io"
     tag: "3.5.0-debian-10-r24"
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What this PR does / why we need it:
Adds missing pahType to milvus ingress definition.
It enables the use of e.g. Harbor Proxy Cache for etcd and minio images.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
