### PR TITLE
Upgrade pulsar from 2.7.3 to 2.8.2

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.0"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 3.0.4
+version: 3.0.5
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/ci/cluster-values.yaml
+++ b/charts/milvus/ci/cluster-values.yaml
@@ -37,7 +37,7 @@ pulsar:
         cpu: 0.2
         memory: 512Mi
     configData:
-      BOOKIE_MEM: "\"-Xms512m -Xmx512m -XX:MaxDirectMemorySize=512m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintHeapAtGC -verbosegc -XX:G1LogLevel=finest\""
+      BOOKIE_MEM: "\"-Xms512m -Xmx512m -XX:MaxDirectMemorySize=512m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem -verbosegc\""
   zookeeper:
     replicaCount: 1
     resources:
@@ -45,7 +45,7 @@ pulsar:
         cpu: 0.1
         memory: 256Mi
     configData:
-      PULSAR_MEM: "\"-Xms256m -Xmx256m -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:+DisableExplicitGC -XX:+PerfDisableSharedMem -Dzookeeper.forceSync=no\""
+      PULSAR_MEM: "\"-Xms256m -Xmx256m -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760 -XX:+DoEscapeAnalysis -XX:+DisableExplicitGC -XX:+PerfDisableSharedMem -Dzookeeper.forceSync=no\""
   broker:
     replicaCount: 1
     resources:

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -445,27 +445,23 @@ pulsar:
     broker:
       repository: apachepulsar/pulsar
       pullPolicy: IfNotPresent
-      tag: 2.7.3
-    function:
-      repository: apachepulsar/pulsar
-      pullPolicy: IfNotPresent
-      tag: 2.7.3
+      tag: 2.8.2
     zookeeper:
       repository: apachepulsar/pulsar
       pullPolicy: IfNotPresent
-      tag: 2.7.3
+      tag: 2.8.2
     bookkeeper:
       repository: apachepulsar/pulsar
       pullPolicy: IfNotPresent
-      tag: 2.7.3
+      tag: 2.8.2
     proxy:
       repository: apachepulsar/pulsar
       pullPolicy: IfNotPresent
-      tag: 2.7.3
+      tag: 2.8.2
     bastion:
       repository: apachepulsar/pulsar
       pullPolicy: IfNotPresent
-      tag: 2.7.3
+      tag: 2.8.2
 
   zookeeper:
     resources:
@@ -473,7 +469,7 @@ pulsar:
         memory: 1024Mi
         cpu: 0.3
     configData:
-      PULSAR_MEM: "\"-Xms1024m -Xmx1024m -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:+DisableExplicitGC -XX:+PerfDisableSharedMem -Dzookeeper.forceSync=no\""
+      PULSAR_MEM: "\"-Xms1024m -Xmx1024m -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760 -XX:+DoEscapeAnalysis -XX:+DisableExplicitGC -XX:+PerfDisableSharedMem -Dzookeeper.forceSync=no\""
 
   bookkeeper:
     replicaCount: 3
@@ -489,7 +485,7 @@ pulsar:
         memory: 2048Mi
         cpu: 1
     configData:
-      BOOKIE_MEM: "\"-Xms4096m -Xmx4096m -XX:MaxDirectMemorySize=8192m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintHeapAtGC -verbosegc -XX:G1LogLevel=finest\""
+      BOOKIE_MEM: "\"-Xms4096m -Xmx4096m -XX:MaxDirectMemorySize=8192m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem -verbosegc\""
       nettyMaxFrameSizeBytes: "104867840"
 
   broker:


### PR DESCRIPTION
Signed-off-by: Edward Zeng <jie.zeng@zilliz.com>

## What this PR does / why we need it:
Pulsar 2.7.3 uses old log4j2 version and contains security vulnerability. 
Pulsar 2.8.4 fixes those security issues.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
