### PR TITLE
Fix retention duration config

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.0"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 3.0.5
+version: 3.0.6
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/config.tpl
+++ b/charts/milvus/templates/config.tpl
@@ -219,7 +219,6 @@ dataCoord:
 
   compaction:
     enableAutoCompaction: {{ .Values.dataCoordinator.compaction.enableAutoCompaction }}
-    retentionDuration: {{ .Values.dataCoordinator.compaction.retentionDuration }}
 
   gc:
     interval: {{ .Values.dataCoordinator.gc.interval }} # gc interval in seconds
@@ -285,6 +284,7 @@ msgChannel:
 common:
   defaultPartitionName: "_default"  # default partition name for a collection
   defaultIndexName: "_default_idx"  # default index name
+  retentionDuration: {{ .Values.dataCoordinator.compaction.retentionDuration }}
 
 knowhere:
   simdType: {{ .Values.knowhere.simdType }}  # default to auto


### PR DESCRIPTION
Signed-off-by: Edward Zeng <jie.zeng@zilliz.com>

## What this PR does / why we need it:
`retentionDuration` config has been moved from `dataCoord` section to `common`.
/cc @zwd1208 @Bennu-Li 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
