### PR TITLE
milvus-attu: add https parameter to attu ingress config

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.2"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 3.0.21
+version: 3.0.23
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.2"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 3.0.20
+version: 3.0.21
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/_helpers.tpl
+++ b/charts/milvus/templates/_helpers.tpl
@@ -123,7 +123,7 @@ Create milvus attu env name.
 {{- define "milvus.attu.env" -}}
 - name: HOST_URL
 {{- if .Values.attu.ingress.enabled }}
-  {{- if .Values.attu.ingress.tls }}
+  {{- if or .Values.attu.ingress.tls .Values.attu.ingress.https }}
   value: https://{{ first .Values.attu.ingress.hosts }}
   {{- else }}
   value: http://{{ first .Values.attu.ingress.hosts }}


### PR DESCRIPTION
## What this PR does / why we need it:

We use Pomerium. For our setup we don't define `attu.ingress.tls` but still need `HOST_URL` in the attu deployment to be https. With this change one can set `attu.ingress.https` to accomplish that without tls config.

## Checklist
- [X] PR only contains changes for one chart
