### PR TITLE
Add support for using pulsar or kafka as milvus standalone message queue

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.2"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 3.0.22
+version: 3.0.23
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -34,7 +34,18 @@ Assume the release name is `my-release`:
 # Helm v3.x
 $ helm upgrade --install my-release --set cluster.enabled=false --set etcd.replicaCount=1 --set pulsar.enabled=false --set minio.mode=standalone milvus/milvus
 ```
+By default, milvus standalone uses `rocksmq` as message queue. You can also use `pulsar` or `kafka` as message queue:
+```bash
+# Helm v3.x
+# Milvus Standalone with pulsar as message queue
+$ helm upgrade --install my-release --set cluster.enabled=false --set standalone.messageQueue=pulsar --set etcd.replicaCount=1 --set pulsar.enabled=true --set minio.mode=standalone milvus/milvus
+```
 
+```bash
+# Helm v3.x
+# Milvus Standalone with kafka as message queue
+$ helm upgrade --install my-release --set cluster.enabled=false --set standalone.messageQueue=kafka --set etcd.replicaCount=1 --set pulsar.enabled=false --set kafka.enabled=true --set minio.mode=standalone milvus/milvus
+```
 > **Tip**: To list all releases, using `helm list`.
 
 ### Deploy Milvus with cluster mode
@@ -45,7 +56,7 @@ Assume the release name is `my-release`:
 # Helm v3.x
 $ helm upgrade --install my-release milvus/milvus
 ```
-By default, milvus cluster uses `Pulsar` as message queue. You can also use `Kafka` instead of `Pulsar` for milvus cluster:
+By default, milvus cluster uses `pulsar` as message queue. You can also use `kafka` instead of `pulsar` for milvus cluster:
 
 ```bash
 # Helm v3.x
@@ -205,6 +216,7 @@ The following table lists the configurable parameters of the Milvus Standalone c
 | `standalone.affinity`                     | Affinity settings for Milvus Standalone pods assignment | `{}`                                          |
 | `standalone.tolerations`                  | Toleration labels for Milvus Standalone pods assignment | `[]`                                          |
 | `standalone.extraEnv`                     | Additional Milvus Standalone container environment variables | `[]`                                     |
+| `standalone.messageQueue`                     | Message queue for Milvus Standalone: rocksmq, pulsar, kafka | `rocksmq`                                     |
 | `standalone.rocksmq.retentionTimeInMinutes` | Set the retention time of rocksmq           | `10080`                                                 |
 | `standalone.rocksmq.retentionSizeInMB`    | Set the retention size of rocksmq             | `0`                                                     |
 | `standalone.persistence.enabled`          | Use persistent volume to store Milvus standalone data | `true`                                          |

--- a/charts/milvus/templates/config.tpl
+++ b/charts/milvus/templates/config.tpl
@@ -85,11 +85,15 @@ kafka:
 {{- end }}
 {{- end }}
 
+{{- if and (not .Values.cluster.enabled) (eq .Values.standalone.messageQueue "rocksmq") }}
+
 rocksmq:
   path: "{{ .Values.standalone.persistence.mountPath }}/rdb_data"
   rocksmqPageSize: "{{ .Values.standalone.rocksmq.rocksmqPageSize }}"  # 2 GB
   retentionTimeInMinutes: {{ .Values.standalone.rocksmq.retentionTimeInMinutes }}
   retentionSizeInMB: {{ .Values.standalone.rocksmq.retentionSizeInMB }}
+
+{{- end }}
 
 rootCoord:
 {{- if .Values.cluster.enabled }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -156,6 +156,9 @@ standalone:
   - name: GODEBUG
     value: "madvdontneed=1"
 
+  ## Default message queue for milvus standalone
+  ## Supported value: rocksmq, pulsar and kafka
+  messageQueue: rocksmq
   rocksmq:
     retentionTimeInMinutes: 10080  ## 7 days
     retentionSizeInMB: 8192        ## 8 GB


### PR DESCRIPTION
Signed-off-by: Edward Zeng <jie.zeng@zilliz.com>

## What this PR does / why we need it:
/cc @zwd1208 @Bennu-Li 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
