### PR TITLE
[milvus] externalKafka: Allow configuring kafka sasl_plain authentication

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.2"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 3.0.24
+version: 3.0.25
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -150,6 +150,10 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `externalPulsar.port`                     | The port of the external Pulsar               | `6650`                                                  |
 | `externalKafka.enabled`                   | Enable or disable external Kafka             | `false`                                                 |
 | `externalKafka.brokerList`                | The brokerList of the external Kafka separated by comma               | `localhost:9092`                                             |
+| `externalKafka.securityProtocol`          | The securityProtocol used for kafka authentication                    | `SASL_SSL`                                                   |
+| `externalKafka.sasl.mechanisms`           | SASL mechanism to use for kafka authentication                        | `PLAIN`                                                      |
+| `externalKafka.sasl.username`             | username for PLAIN or SASL/PLAIN authentication                       | ``                                                           |
+| `externalKafka.sasl.password`             | password for PLAIN or SASL/PLAIN authentication                       | ``                                                           |
 =======
 | Parameter                                             | Description                                                  | Default                                                      |
 | ----------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |

--- a/charts/milvus/templates/config.tpl
+++ b/charts/milvus/templates/config.tpl
@@ -75,6 +75,14 @@ pulsar:
 
 kafka:
   brokerList: {{ .Values.externalKafka.brokerList }}
+  securityProtocol: {{ .Values.externalKafka.securityProtocol }}
+  saslMechanisms: {{ .Values.externalKafka.sasl.mechanisms }}
+{{- if .Values.externalKafka.sasl.username }}
+  saslUsername: {{ .Values.externalKafka.sasl.username }}
+{{- end }}
+{{- if .Values.externalKafka.sasl.password }}
+  saslPassword: {{ .Values.externalKafka.sasl.password }}
+{{- end }}
 {{- else if .Values.kafka.enabled }}
 
 kafka:

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -739,3 +739,8 @@ externalPulsar:
 externalKafka:
   enabled: false
   brokerList: localhost:9092
+  securityProtocol: SASL_SSL
+  sasl:
+    mechanisms: PLAIN
+    username: ""
+    password: ""


### PR DESCRIPTION
## What this PR does / why we need it:
Allows to configure Kafka SASL/PLAIN or PLAIN authentication for external kafka. External kafka could be a managed kafka cluster (e.g. Amazon MSK or Confluent), which requires authentication.

- The service side code seems to be handle this already -https://github.com/milvus-io/milvus/blob/4ae1ca2cacc15e03afd8853ab4dedf10ba61a2d6/internal/util/paramtable/base_table.go#L186.
- fixes #340 

Please let me know if any more changes are required in this PR.


## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
