### PR TITLE
Use new etcd image to mitigate etcd pod crash

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.0.2"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 3.0.26
+version: 3.0.27
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -410,7 +410,8 @@ etcd:
   name: etcd
   replicaCount: 3
   image:
-    tag: "3.5.0-debian-10-r24"
+    repository: "milvusdb/etcd"
+    tag: "3.5.0-r6"
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
Signed-off-by: Edward Zeng <jie.zeng@zilliz.com>

## What this PR does / why we need it:
Recently many users encountered etcd pod keeping crash issue because of `empty member_id`, we try to fix the issue in our fork at https://github.com/milvus-io/bitnami-docker-etcd.

For now we'll use this fork to build etcd image which is published  at `milvusdb/etcd`. 

/cc @zwd1208 @Bennu-Li 
## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
