### PR TITLE
Allow to set annotations for attu service

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.1.4"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 3.2.11
+version: 3.2.12
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/attu-svc.yaml
+++ b/charts/milvus/templates/attu-svc.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
 {{ include "milvus.labels" . | indent 4 }}
     component: "attu"
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{- if (or (eq .Values.attu.service.type "ClusterIP") (empty .Values.attu.service.type)) }}
   type: ClusterIP


### PR DESCRIPTION
## What this PR does / why we need it:

Currently it's not possible to set annotations for the attu service, although it's documented through the values file, that it should be possible. This PR fixes that issue.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [milvus] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
