### PR TITLE
Milvus - Add / Customize Service Account

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.1.4"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 3.2.6
+version: 3.2.8
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -115,6 +115,10 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `ingress.labels`                          | Ingress labels                                | `{}`                                                    |
 | `ingress.hosts`                           | Ingress hostnames                             | `[]`                                                    |
 | `ingress.tls`                             | Ingress TLS configuration                     | `[]`                                                    |
+| `serviceAccount.create`                   | Create a custom service account               | `false`                                                 |
+| `serviceAccount.name`                     | Service Account name                          | `milvus`                                                |
+| `serviceAccount.annotations`              | Service Account Annotations                   | `{}`                                                    |
+| `serviceAccount.labels`                   | Service Account labels                        | `{}`                                                    |
 | `metrics.enabled`                         | Export Prometheus monitoring metrics          | `true`                                                  |
 | `metrics.serviceMonitor.enabled`          | Create ServiceMonitor for Prometheus operator | `false`                                                 |
 | `metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `unset`         |

--- a/charts/milvus/templates/_helpers.tpl
+++ b/charts/milvus/templates/_helpers.tpl
@@ -118,6 +118,17 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+  Create the name of the service account to use for the Milvus components
+  */}}
+  {{- define "milvus.serviceAccount" -}}
+  {{- if .Values.serviceAccount.create -}}
+      {{ default "milvus" .Values.serviceAccount.name }}
+  {{- else -}}
+      {{ default "default" .Values.serviceAccount.name }}
+  {{- end -}}
+  {{- end -}}
+
+{{/*
 Create milvus attu env name.
 */}}
 {{- define "milvus.attu.env" -}}

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "milvus.serviceAccount" . }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "milvus.serviceAccount" . }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}
@@ -138,7 +139,6 @@ spec:
       tolerations:
 {{ toYaml .Values.dataNode.tolerations | indent 8 }}
     {{- end }}
-
       volumes:
       - name: milvus-config
         configMap:

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "milvus.serviceAccount" . }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "milvus.serviceAccount" . }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "milvus.serviceAccount" . }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "milvus.serviceAccount" . }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "milvus.serviceAccount" . }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "milvus.serviceAccount" . }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/templates/serviceaccount.yaml
+++ b/charts/milvus/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "milvus.serviceAccount" . }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+  labels:
+{{ include "milvus.labels" . | indent 4 }}
+{{- with .Values.serviceAccount.labels }}
+  {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ include "milvus.ud.annotations" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "milvus.serviceAccount" . }}
       {{- if .Values.image.all.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.all.pullSecrets }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -75,6 +75,12 @@ ingress:
   #    hosts:
   #      - milvus-example.local
 
+serviceAccount:
+  create: false
+  name:
+  annotations:
+  labels:
+
 metrics:
   enabled: true
 


### PR DESCRIPTION
## What this PR does / why we need it:

This adds the ability to create and use a service account for the Milvus components.  This can be useful for adding annotations to a service account for things like IRSA in EKS to inject a IAM role for Minio/S3 (https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/). Example use in the chart:

```
serviceAccount:
  create: true
  name:
  annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/milvus-s3
```

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
