### PR TITLE
Add dynamic config for milvus

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.2.0"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 3.3.1
+version: 3.3.2
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -103,6 +103,7 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `image.all.tag`                           | Image tag                                     | `v2.1.4`                           |
 | `image.all.pullPolicy`                    | Image pull policy                             | `IfNotPresent`                                          |
 | `image.all.pullSecrets`                   | Image pull secrets                            | `{}`                                                    |
+| `extraConfigFiles`                        | Extra config to override default milvus.yaml  | `user.yaml:`                                                     |
 | `service.type`                            | Service type                                  | `ClusterIP`                                             |
 | `service.port`                            | Port where service is exposed                 | `19530`                                                 |
 | `service.nodePort`                        | Service nodePort                              | `unset`                                                 |
@@ -311,6 +312,7 @@ The following table lists the configurable parameters of the Milvus Query Node c
 | `queryNode.extraEnv`                      | Additional Milvus Query Node container environment variables | `[]`                                     |
 | `queryNode.grouping.enabled`              | Enable grouping small nq search |               `true`                                     |
 | `queryNode.grouping.maxNQ`                | Grouping small nq search max threshold |               `1000`                                     |
+| `queryNode.scheduler.maxReadConcurrentRatio`                | Concurrency ratio of read tasks |               `2.0`                                     |
 
 ### Milvus Index Coordinator Deployment Configuration
 

--- a/charts/milvus/templates/config.tpl
+++ b/charts/milvus/templates/config.tpl
@@ -102,12 +102,16 @@ minio:
 
 {{- if .Values.externalPulsar.enabled }}
 
+messageQueue: pulsar
+
 pulsar:
   address: {{ .Values.externalPulsar.host }}
   port: {{ .Values.externalPulsar.port }}
   maxMessageSize: {{ .Values.externalPulsar.maxMessageSize }}
 
 {{- else if .Values.pulsar.enabled }}
+
+messageQueue: pulsar
 
 pulsar:
 {{- if contains .Values.pulsar.name .Release.Name }}
@@ -121,6 +125,8 @@ pulsar:
 
 {{- if .Values.externalKafka.enabled }}
 
+messageQueue: kafka
+
 kafka:
   brokerList: {{ .Values.externalKafka.brokerList }}
   securityProtocol: {{ .Values.externalKafka.securityProtocol }}
@@ -133,6 +139,8 @@ kafka:
 {{- end }}
 {{- else if .Values.kafka.enabled }}
 
+messageQueue: kafka
+
 kafka:
 {{- if contains .Values.kafka.name .Release.Name }}
   brokerList: {{ .Release.Name }}:{{ .Values.kafka.service.ports.client }}
@@ -142,6 +150,8 @@ kafka:
 {{- end }}
 
 {{- if and (not .Values.cluster.enabled) (eq .Values.standalone.messageQueue "rocksmq") }}
+
+messageQueue: rocksmq
 
 rocksmq:
   path: "{{ .Values.standalone.persistence.mountPath }}/rdb_data"
@@ -228,7 +238,7 @@ queryNode:
   scheduler:
     receiveChanSize: 10240
     unsolvedQueueSize: 10240
-    maxReadConcurrency: 0 # maximum concurrency of read task. if set to less or equal 0, it means no uppper limit.
+    maxReadConcurrentRatio: "{{ .Values.queryNode.scheduler.maxReadConcurrentRatio }}"
     cpuRatio: 10.0 # ratio used to estimate read task cpu usage.
 
   grouping:

--- a/charts/milvus/templates/configmap.yaml
+++ b/charts/milvus/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "milvus.fullname" . }}
 data:
-  milvus.yaml: |+
+  default.yaml: |+
     {{- include "milvus.config" . | nindent 4 }}
 
 {{- range $key, $value := .Values.extraConfigFiles }}

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -40,8 +40,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.dataCoordinator.heaptrack.enabled }}
       initContainers:
+      {{- if .Values.dataCoordinator.heaptrack.enabled }}
       - name: heaptrack
         command:
         - /bin/bash
@@ -51,16 +51,26 @@ spec:
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
         volumeMounts:
         - mountPath: /milvus/tools
-          name: heaptrack
+          name: tools
       {{- end }}
+      - name: config
+        command:
+        - /cp
+        - /run-helm.sh,/merge
+        - /milvus/tools/run-helm.sh,/milvus/tools/merge
+        image: "{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag }}"
+        imagePullPolicy: {{ .Values.image.tools.pullPolicy}}
+        volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
       containers:
       - name: datacoord
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
         {{- if .Values.dataCoordinator.heaptrack.enabled }}
-        args: ["/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "datacoord"]
+        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "/milvus/tools/run-helm.sh", "milvus", "run", "datacoord" ]
         {{- else }}
-        args: [ "milvus", "run", "datacoord" ]
+        args: [ "/milvus/tools/run-helm.sh", "milvus", "run", "datacoord" ]
         {{- end }}
         env:
         {{- if .Values.dataCoordinator.heaptrack.enabled }}
@@ -103,18 +113,20 @@ spec:
           {{- toYaml .Values.dataCoordinator.resources | nindent 10 }}
         volumeMounts:
         - name: milvus-config
-          mountPath: /milvus/configs/milvus.yaml
-          subPath: milvus.yaml
+          mountPath: /milvus/configs/default.yaml
+          subPath: default.yaml
+          readOnly: true
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: user.yaml
           readOnly: true
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
           subPath: {{ .Values.log.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if .Values.dataCoordinator.heaptrack.enabled }}
         - mountPath: /milvus/tools
-          name: heaptrack
-        {{- end }}
+          name: tools
 
     {{- if and (.Values.nodeSelector) (not .Values.dataCoordinator.nodeSelector) }}
       nodeSelector:
@@ -150,8 +162,6 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if .Values.dataCoordinator.heaptrack.enabled }}
-      - name: heaptrack
+      - name: tools
         emptyDir: {}
-      {{- end }}
 {{- end }}

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -39,8 +39,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.dataNode.heaptrack.enabled }}
       initContainers:
+      {{- if .Values.dataNode.heaptrack.enabled }}
       - name: heaptrack
         command:
         - /bin/bash
@@ -50,16 +50,26 @@ spec:
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
         volumeMounts:
         - mountPath: /milvus/tools
-          name: heaptrack
+          name: tools
       {{- end }}
+      - name: config
+        command:
+        - /cp
+        - /run-helm.sh,/merge
+        - /milvus/tools/run-helm.sh,/milvus/tools/merge
+        image: "{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag }}"
+        imagePullPolicy: {{ .Values.image.tools.pullPolicy}}
+        volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
       containers:
       - name: datanode
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
         {{- if .Values.dataNode.heaptrack.enabled }}
-        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "datanode" ]
+        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "/milvus/tools/run-helm.sh", "milvus", "run", "datanode" ]
         {{- else }}
-        args: [ "milvus", "run", "datanode" ]
+        args: [ "/milvus/tools/run-helm.sh", "milvus", "run", "datanode" ]
         {{- end }}
         env:
         {{- if .Values.dataNode.heaptrack.enabled }}
@@ -102,18 +112,20 @@ spec:
           {{- toYaml .Values.dataNode.resources | nindent 10 }}
         volumeMounts:
         - name: milvus-config
-          mountPath: /milvus/configs/milvus.yaml
-          subPath: milvus.yaml
+          mountPath: /milvus/configs/default.yaml
+          subPath: default.yaml
+          readOnly: true
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: user.yaml
           readOnly: true
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
           subPath: {{ .Values.log.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if .Values.dataNode.heaptrack.enabled }}
         - mountPath: /milvus/tools
-          name: heaptrack
-        {{- end }}
+          name: tools
 
     {{- if and (.Values.nodeSelector) (not .Values.dataNode.nodeSelector) }}
       nodeSelector:
@@ -148,8 +160,6 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if .Values.dataNode.heaptrack.enabled }}
-      - name: heaptrack
+      - name: tools
         emptyDir: {}
-      {{- end }}
 {{- end }}

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -40,8 +40,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.indexCoordinator.heaptrack.enabled }}
       initContainers:
+      {{- if .Values.indexCoordinator.heaptrack.enabled }}
       - name: heaptrack
         command:
         - /bin/bash
@@ -51,16 +51,26 @@ spec:
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
         volumeMounts:
         - mountPath: /milvus/tools
-          name: heaptrack
+          name: tools
       {{- end }}
+      - name: config
+        command:
+        - /cp
+        - /run-helm.sh,/merge
+        - /milvus/tools/run-helm.sh,/milvus/tools/merge
+        image: "{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag }}"
+        imagePullPolicy: {{ .Values.image.tools.pullPolicy}}
+        volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
       containers:
       - name: indexcoord
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
         {{- if .Values.indexCoordinator.heaptrack.enabled }}
-        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "indexcoord" ]
+        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "/milvus/tools/run-helm.sh", "milvus", "run", "indexcoord" ]
         {{- else }}
-        args: [ "milvus", "run", "indexcoord" ]
+        args: [ "/milvus/tools/run-helm.sh", "milvus", "run", "indexcoord" ]
         {{- end }}
         env:
         {{- if .Values.indexCoordinator.heaptrack.enabled }}
@@ -103,18 +113,20 @@ spec:
           {{- toYaml .Values.indexCoordinator.resources | nindent 10 }}
         volumeMounts:
         - name: milvus-config
-          mountPath: /milvus/configs/milvus.yaml
-          subPath: milvus.yaml
+          mountPath: /milvus/configs/default.yaml
+          subPath: default.yaml
+          readOnly: true
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: user.yaml
           readOnly: true
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
           subPath: {{ .Values.log.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if .Values.indexCoordinator.heaptrack.enabled }}
         - mountPath: /milvus/tools
-          name: heaptrack
-        {{- end }}
+          name: tools
 
     {{- if and (.Values.nodeSelector) (not .Values.indexCoordinator.nodeSelector) }}
       nodeSelector:
@@ -150,8 +162,6 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if .Values.indexCoordinator.heaptrack.enabled }}
-      - name: heaptrack
+      - name: tools
         emptyDir: {}
-      {{- end }}
 {{- end }}

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -38,8 +38,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.indexNode.heaptrack.enabled }}
       initContainers:
+      {{- if .Values.indexNode.heaptrack.enabled }}
       - name: heaptrack
         command:
         - /bin/bash
@@ -49,16 +49,26 @@ spec:
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
         volumeMounts:
         - mountPath: /milvus/tools
-          name: heaptrack
+          name: tools
       {{- end }}
+      - name: config
+        command:
+        - /cp
+        - /run-helm.sh,/merge
+        - /milvus/tools/run-helm.sh,/milvus/tools/merge
+        image: "{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag }}"
+        imagePullPolicy: {{ .Values.image.tools.pullPolicy}}
+        volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
       containers:
       - name: indexnode
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
         {{- if .Values.indexNode.heaptrack.enabled }}
-        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "indexnode" ]
+        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "/milvus/tools/run-helm.sh", "milvus", "run", "indexnode" ]
         {{- else }}
-        args: [ "milvus", "run", "indexnode" ]
+        args: [ "/milvus/tools/run-helm.sh", "milvus", "run", "indexnode" ]
         {{- end }}
         env:
         {{- if .Values.indexNode.heaptrack.enabled }}
@@ -108,18 +118,20 @@ spec:
           {{- toYaml .Values.indexNode.resources | nindent 10 }}
         volumeMounts:
         - name: milvus-config
-          mountPath: /milvus/configs/milvus.yaml
-          subPath: milvus.yaml
+          mountPath: /milvus/configs/default.yaml
+          subPath: default.yaml
+          readOnly: true
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: user.yaml
           readOnly: true
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
           subPath: {{ .Values.log.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if .Values.indexNode.heaptrack.enabled }}
         - mountPath: /milvus/tools
-          name: heaptrack
-        {{- end }}
+          name: tools
         {{- if .Values.indexNode.disk.enabled }}
         - mountPath: /milvus/data
           name: disk
@@ -160,10 +172,8 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if .Values.indexNode.heaptrack.enabled }}
-      - name: heaptrack
+      - name: tools
         emptyDir: {}
-      {{- end }}
       {{- if .Values.indexNode.disk.enabled }}
       - name: disk
         emptyDir: {}

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -39,8 +39,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.proxy.heaptrack.enabled }}
       initContainers:
+      {{- if .Values.proxy.heaptrack.enabled }}
       - name: heaptrack
         command:
         - /bin/bash
@@ -50,16 +50,26 @@ spec:
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
         volumeMounts:
         - mountPath: /milvus/tools
-          name: heaptrack
+          name: tools
       {{- end }}
+      - name: config
+        command:
+        - /cp
+        - /run-helm.sh,/merge
+        - /milvus/tools/run-helm.sh,/milvus/tools/merge
+        image: "{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag }}"
+        imagePullPolicy: {{ .Values.image.tools.pullPolicy}}
+        volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
       containers:
       - name: proxy
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
         {{- if .Values.proxy.heaptrack.enabled }}
-        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "proxy" ]
+        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "/milvus/tools/run-helm.sh", "milvus", "run", "proxy" ]
         {{- else }}
-        args: [ "milvus", "run", "proxy" ]
+        args: [ "/milvus/tools/run-helm.sh", "milvus", "run", "proxy" ]
         {{- end }}
         env:
         {{- if .Values.proxy.heaptrack.enabled }}
@@ -102,19 +112,20 @@ spec:
           {{- toYaml .Values.proxy.resources | nindent 10 }}
         volumeMounts:
         - name: milvus-config
-          mountPath: /milvus/configs/milvus.yaml
-          subPath: milvus.yaml
+          mountPath: /milvus/configs/default.yaml
+          subPath: default.yaml
+          readOnly: true
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: user.yaml
           readOnly: true
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
           subPath: {{ .Values.log.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if .Values.proxy.heaptrack.enabled }}
         - mountPath: /milvus/tools
-          name: heaptrack
-        {{- end }}
-
+          name: tools
 
     {{- if and (.Values.nodeSelector) (not .Values.proxy.nodeSelector) }}
       nodeSelector:
@@ -150,8 +161,6 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if .Values.proxy.heaptrack.enabled }}
-      - name: heaptrack
+      - name: tools
         emptyDir: {}
-      {{- end }}
 {{- end }}

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -40,8 +40,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.queryCoordinator.heaptrack.enabled }}
       initContainers:
+      {{- if .Values.queryCoordinator.heaptrack.enabled }}
       - name: heaptrack
         command:
         - /bin/bash
@@ -51,16 +51,26 @@ spec:
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
         volumeMounts:
         - mountPath: /milvus/tools
-          name: heaptrack
+          name: tools
       {{- end }}
+      - name: config
+        command:
+        - /cp
+        - /run-helm.sh,/merge
+        - /milvus/tools/run-helm.sh,/milvus/tools/merge
+        image: "{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag }}"
+        imagePullPolicy: {{ .Values.image.tools.pullPolicy}}
+        volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
       containers:
       - name: querycoord
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
         {{- if .Values.queryCoordinator.heaptrack.enabled }}
-        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "querycoord" ]
+        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "/milvus/tools/run-helm.sh", "milvus", "run", "querycoord" ]
         {{- else }}
-        args: [ "milvus", "run", "querycoord" ]
+        args: [ "/milvus/tools/run-helm.sh", "milvus", "run", "querycoord" ]
         {{- end }}
         env:
         {{- if .Values.queryCoordinator.heaptrack.enabled }}
@@ -103,18 +113,20 @@ spec:
           {{- toYaml .Values.queryCoordinator.resources | nindent 10 }}
         volumeMounts:
         - name: milvus-config
-          mountPath: /milvus/configs/milvus.yaml
-          subPath: milvus.yaml
+          mountPath: /milvus/configs/default.yaml
+          subPath: default.yaml
+          readOnly: true
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: user.yaml
           readOnly: true
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
           subPath: {{ .Values.log.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if .Values.queryCoordinator.heaptrack.enabled }}
         - mountPath: /milvus/tools
-          name: heaptrack
-        {{- end }}
+          name: tools
 
     {{- if and (.Values.nodeSelector) (not .Values.queryCoordinator.nodeSelector) }}
       nodeSelector:
@@ -150,8 +162,6 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if .Values.queryCoordinator.heaptrack.enabled }}
-      - name: heaptrack
+      - name: tools
         emptyDir: {}
-      {{- end }}
 {{- end }}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -38,8 +38,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.queryNode.heaptrack.enabled }}
       initContainers:
+      {{- if .Values.queryNode.heaptrack.enabled }}
       - name: heaptrack
         command:
         - /bin/bash
@@ -49,16 +49,26 @@ spec:
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
         volumeMounts:
         - mountPath: /milvus/tools
-          name: heaptrack
+          name: tools
       {{- end }}
+      - name: config
+        command:
+        - /cp
+        - /run-helm.sh,/merge
+        - /milvus/tools/run-helm.sh,/milvus/tools/merge
+        image: "{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag }}"
+        imagePullPolicy: {{ .Values.image.tools.pullPolicy}}
+        volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
       containers:
       - name: querynode
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
         {{- if .Values.queryNode.heaptrack.enabled }}
-        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "querynode" ]
+        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "/milvus/tools/run-helm.sh", "milvus", "run", "querynode" ]
         {{- else }}
-        args: [ "milvus", "run", "querynode" ]
+        args: [ "/milvus/tools/run-helm.sh", "milvus", "run", "querynode" ]
         {{- end }}
         env:
         {{- if .Values.queryNode.heaptrack.enabled }}
@@ -108,18 +118,20 @@ spec:
           {{- toYaml .Values.queryNode.resources | nindent 10 }}
         volumeMounts:
         - name: milvus-config
-          mountPath: /milvus/configs/milvus.yaml
-          subPath: milvus.yaml
+          mountPath: /milvus/configs/default.yaml
+          subPath: default.yaml
+          readOnly: true
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: user.yaml
           readOnly: true
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
           subPath: {{ .Values.log.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if .Values.queryNode.heaptrack.enabled }}
         - mountPath: /milvus/tools
-          name: heaptrack
-        {{- end }}
+          name: tools
         {{- if .Values.queryNode.disk.enabled }}
         - mountPath: /milvus/data
           name: disk
@@ -159,10 +171,8 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if .Values.queryNode.heaptrack.enabled }}
-      - name: heaptrack
+      - name: tools
         emptyDir: {}
-      {{- end }}
       {{- if .Values.queryNode.disk.enabled }}
       - name: disk
         emptyDir: {}

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -40,8 +40,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.rootCoordinator.heaptrack.enabled }}
       initContainers:
+      {{- if .Values.rootCoordinator.heaptrack.enabled }}
       - name: heaptrack
         command:
         - /bin/bash
@@ -51,8 +51,18 @@ spec:
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
         volumeMounts:
         - mountPath: /milvus/tools
-          name: heaptrack
+          name: tools
       {{- end }}
+      - name: config
+        command:
+        - /cp
+        - /run-helm.sh,/merge
+        - /milvus/tools/run-helm.sh,/milvus/tools/merge
+        image: "{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag }}"
+        imagePullPolicy: {{ .Values.image.tools.pullPolicy}}
+        volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
       containers:
       - name: rootcoord
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
@@ -60,7 +70,7 @@ spec:
         {{- if .Values.rootCoordinator.heaptrack.enabled }}
         args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "rootcoord" ]
         {{- else }}
-        args: [ "milvus", "run", "rootcoord" ]
+        args: [ "/milvus/tools/run-helm.sh", "milvus", "run", "rootcoord" ]
         {{- end }}
         env:
         {{- if .Values.rootCoordinator.heaptrack.enabled }}
@@ -103,18 +113,20 @@ spec:
           {{- toYaml .Values.rootCoordinator.resources | nindent 10 }}
         volumeMounts:
         - name: milvus-config
-          mountPath: /milvus/configs/milvus.yaml
-          subPath: milvus.yaml
+          mountPath: /milvus/configs/default.yaml
+          subPath: default.yaml
+          readOnly: true
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: user.yaml
           readOnly: true
         {{- if .Values.log.persistence.enabled }}
         - name: milvus-logs-disk
           mountPath: {{ .Values.log.persistence.mountPath | quote }}
           subPath: {{ .Values.log.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if .Values.rootCoordinator.heaptrack.enabled }}
         - mountPath: /milvus/tools
-          name: heaptrack
-        {{- end }}
+          name: tools
 
     {{- if and (.Values.nodeSelector) (not .Values.rootCoordinator.nodeSelector) }}
       nodeSelector:
@@ -150,8 +162,6 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if .Values.rootCoordinator.heaptrack.enabled }}
-      - name: heaptrack
+      - name: tools
         emptyDir: {}
-      {{- end }}
 {{- end }}

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -40,8 +40,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.standalone.heaptrack.enabled }}
       initContainers:
+      {{- if .Values.standalone.heaptrack.enabled }}
       - name: heaptrack
         command:
         - /bin/bash
@@ -51,16 +51,26 @@ spec:
         imagePullPolicy: {{ .Values.heaptrack.image.pullPolicy }}
         volumeMounts:
         - mountPath: /milvus/tools
-          name: heaptrack
+          name: tools
       {{- end }}
+      - name: config
+        command:
+        - /cp
+        - /run-helm.sh,/merge
+        - /milvus/tools/run-helm.sh,/milvus/tools/merge
+        image: "{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag }}"
+        imagePullPolicy: {{ .Values.image.tools.pullPolicy}}
+        volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
       containers:
       - name: standalone
         image: "{{ .Values.image.all.repository }}:{{ .Values.image.all.tag }}"
         imagePullPolicy: {{ .Values.image.all.pullPolicy }}
         {{- if .Values.standalone.heaptrack.enabled }}
-        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "milvus", "run", "standalone" ]
+        args: [ "/milvus/tools/heaptrack/bin/heaptrack", "/milvus/tools/run-helm.sh", "milvus", "run", "standalone" ]
         {{- else }}
-        args: [ "milvus", "run", "standalone" ]
+        args: [ "/milvus/tools/run-helm.sh", "milvus", "run", "standalone" ]
         {{- end }}
         ports:
           - name: milvus
@@ -109,9 +119,15 @@ spec:
           {{- toYaml .Values.standalone.extraEnv | nindent 8 }}
         {{- end }}
         volumeMounts:
+        - mountPath: /milvus/tools
+          name: tools
         - name: milvus-config
-          mountPath: /milvus/configs/milvus.yaml
-          subPath: milvus.yaml
+          mountPath: /milvus/configs/default.yaml
+          subPath: default.yaml
+          readOnly: true
+        - name: milvus-config
+          mountPath: /milvus/configs/user.yaml
+          subPath: user.yaml
           readOnly: true
         - name: milvus-data-disk
           mountPath: {{ .Values.standalone.persistence.mountPath | quote }}
@@ -156,6 +172,8 @@ spec:
     {{- end }}
 
       volumes:
+      - emptyDir: {}
+        name: tools
       - name: milvus-config
         configMap:
           name: {{ template "milvus.fullname" . }}
@@ -170,10 +188,6 @@ spec:
       - name: milvus-logs-disk
         persistentVolumeClaim:
           claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
-      {{- end }}
-      {{- if .Values.standalone.heaptrack.enabled }}
-      - name: heaptrack
-        emptyDir: {}
       {{- end }}
       {{- if .Values.standalone.disk.enabled }}
       - name: disk

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -13,6 +13,10 @@ image:
     ##
     # pullSecrets:
     #   - myRegistryKeySecretName
+  tools:
+    repository: milvusdb/milvus-config-tool
+    tag: v0.1.0
+    pullPolicy: IfNotPresent
 
 # Global node selector
 # If set, this will apply to all milvus components
@@ -33,6 +37,19 @@ affinity: {}
 # If set, this will apply to all milvus components
 labels: {}
 annotations: {}
+
+# Extra configs for milvus.yaml
+# If set, this config will merge into milvus.yaml
+# Please follow the config structure in the milvus.yaml
+# at https://github.com/milvus-io/milvus/blob/master/configs/milvus.yaml
+# Note: this config will be the top priority which will override the config
+# in the image and helm chart.
+extraConfigFiles:
+  user.yaml: |+
+    #    For example enable rest http for milvus proxy
+    #    proxy:
+    #      http:
+    #        enabled: true
 
 ## Expose the Milvus service to be accessed from outside the cluster (LoadBalancer service).
 ## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
@@ -428,6 +445,9 @@ queryNode:
   grouping:
     enabled: true    # Grouping small nq search
     maxNQ: 1000
+
+  scheduler:
+    maxReadConcurrentRatio: "2.0"
 
 indexCoordinator:
   enabled: true


### PR DESCRIPTION
Signed-off-by: Edward Zeng <jie.zeng@zilliz.com>

## What this PR does / why we need it:
Allow you to user specify extra config for milvus, which has the top priority. Now we have the config merge in the following order:
1. merge the configmap generated by the helm-chart with the `milvus.yaml` in the milvus image
2. merge the extra config `user.yaml` with the step 1 result as the final `milvus.yaml`

So you can specify extra config even if it doesn't support declare in the values.yaml.

/cc @zwd1208 @Bennu-Li 
/hold

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Chart Version bumped
- [x ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
