### PR TITLE
Won't deploy indexcoord when milvus version > v2.3

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.2.2"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.0.2
+version: 4.0.3
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/config.tpl
+++ b/charts/milvus/templates/config.tpl
@@ -184,6 +184,7 @@ queryNode:
   enableDisk: {{ .Values.standalone.disk.enabled }} # Enable querynode load disk index, and search on disk index
 {{- end }}
 
+{{ if lt .Values.image.all.tag "v2.3" }}
 indexCoord:
 {{- if .Values.cluster.enabled }}
   address: {{ template "milvus.indexcoord.fullname" . }}
@@ -191,6 +192,7 @@ indexCoord:
   address: localhost
 {{- end }}
   port: {{ .Values.indexCoordinator.service.port }}
+{{- end }}
 
 indexNode:
   port: 21121

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if lt .Values.image.all.tag "v2.3" }}
 {{- if and .Values.indexCoordinator.enabled .Values.cluster.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -164,4 +165,5 @@ spec:
       {{- end }}
       - name: tools
         emptyDir: {}
+{{- end }}
 {{- end }}

--- a/charts/milvus/templates/indexcoord-svc.yaml
+++ b/charts/milvus/templates/indexcoord-svc.yaml
@@ -1,3 +1,4 @@
+{{- if lt .Values.image.all.tag "v2.3" }}
 {{- if and .Values.indexCoordinator.enabled .Values.cluster.enabled }}
 apiVersion: v1
 kind: Service
@@ -32,4 +33,5 @@ spec:
   selector:
 {{ include "milvus.matchLabels" . | indent 4 }}
     component: "indexcoord"
+{{- end }}
 {{- end }}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -282,6 +282,8 @@ queryNode:
   profiling:
     enabled: false  # Enable live profiling
 
+# Won't deploy indexcoord when milvus version > v2.3, cause indexcoord has been merged into datacoord
+# compared by helm func `lt`
 indexCoordinator:
   enabled: true
   replicas: 1   # Run Index Coordinator mode with replication disabled


### PR DESCRIPTION
Cause the indexcoord has been merged into datacoord,so helm won't deploy indexcoord after v2.3

Signed-off-by: Sheldon <chuanfeng.liu@zilliz.com>

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
