### PR TITLE
Decrease kafka log segment roll duration

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.2.2"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.0.5
+version: 4.0.6
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -158,6 +158,7 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `externalS3.enabled`                      | Enable or disable external S3                 | `false`                                                 |
 | `externalS3.host`                         | The host of the external S3                   | `unset`                                                 |
 | `externalS3.port`                         | The port of the external S3                   | `unset`                                                 |
+| `externalS3.rootPath`                     | The path prefix of the external S3            | `unset`                                                 |
 | `externalS3.accessKey`                    | The Access Key of the external S3             | `unset`                                                 |
 | `externalS3.secretKey`                    | The Secret Key of the external S3             | `unset`                                                 |
 | `externalS3.bucketName`                   | The Bucket Name of the external S3            | `unset`                                                 |

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -725,6 +725,9 @@ kafka:
   maxMessageBytes: _10485760
   defaultReplicationFactor: 3
   offsetsTopicReplicationFactor: 3
+  ## Only enable time based log retention
+  logRetentionHours: 168
+  logRetentionBytes: _-1
   extraEnvVars:
   - name: KAFKA_CFG_MAX_PARTITION_FETCH_BYTES
     value: "5242880"
@@ -734,6 +737,8 @@ kafka:
     value: "10485760"
   - name: KAFKA_CFG_FETCH_MESSAGE_MAX_BYTES
     value: "5242880"
+  - name: KAFKA_CFG_LOG_ROLL_HOURS
+    value: "24"
 
   persistence:
     enabled: true


### PR DESCRIPTION
Signed-off-by: Edward Zeng <jie.zeng@zilliz.com>

## What this PR does / why we need it:
By default, the kafka chart enabled time based retention (7 day) and size based retention (1GB). We'd keep consistent settings for all message queues. So we'd only used time based retention and keep 7 days as default.

And kafka log retention is based on `log segment`, and default `log.roll.hours` is 168 (7 days), so we'd keep a log for at most 14 days. Here we'd decrease `log.roll.hours` to 24 (1 day).
/cc @zwd1208 @Bennu-Li @locustbaby 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
