### PR TITLE
[Milvus]: service portName value templating

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.2.9"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.0.23
+version: 4.0.24
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/README.md
+++ b/charts/milvus/README.md
@@ -161,6 +161,7 @@ The following table lists the configurable parameters of the Milvus Service and 
 | `extraConfigFiles`                        | Extra config to override default milvus.yaml  | `user.yaml:`                                                     |
 | `service.type`                            | Service type                                  | `ClusterIP`                                             |
 | `service.port`                            | Port where service is exposed                 | `19530`                                                 |
+| `service.portName`                        | Useful for [Istio protocol selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/)   | `milvus`                                                |
 | `service.nodePort`                        | Service nodePort                              | `unset`                                                 |
 | `service.annotations`                     | Service annotations                           | `{}`                                                    |
 | `service.labels`                          | Service custom labels                         | `{}`                                                    |

--- a/charts/milvus/templates/service.yaml
+++ b/charts/milvus/templates/service.yaml
@@ -36,7 +36,7 @@ spec:
   type: {{ .Values.service.type }}
 {{- end }}
   ports:
-    - name: milvus
+    - name: {{ .Values.service.portName }}
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: milvus

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -58,6 +58,7 @@ extraConfigFiles:
 service:
   type: ClusterIP
   port: 19530
+  portName: milvus
   nodePort: ""
   annotations: {}
   labels: {}


### PR DESCRIPTION
## What this PR does / why we need it:

Hi! We're running milvus behind Istio service mesh. In order to help Istio proxy TCP traffic to Milvus service, we either need to add the protocol in the name, e.g `grpc-milvus`, or specify `appProtocol: grpc` in the port definition. Both options would work for me, I consider the first one to be less obscure, so I simply added single new `portName` variable in the chart template. So far each time I am upgrading the chart - I am doing this fix manually.

More about Istio protocol selection: [here](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/)

Thanks!

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
