### PR TITLE
[milvus] attu-svc: fix loadBalancerIP issue

### DIFF
--- a/charts/milvus/templates/attu-svc.yaml
+++ b/charts/milvus/templates/attu-svc.yaml
@@ -15,7 +15,7 @@ spec:
 {{- else if eq .Values.attu.service.type "LoadBalancer" }}
   type: LoadBalancer
   {{- if .Values.attu.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.attu.service.loadBalancerIP }}
   {{- end }}
 {{- if .Values.attu.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -404,6 +404,7 @@ attu:
   service:
     type: ClusterIP
     port: 3000
+    # loadBalancerIP: ""
   resources: {}
   ingress:
     enabled: false


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes #459. A typo prevented usage of a given load balancer IP for the Attu service. 

This PR does the two following changes: 
- Fixes the condition checking for existence of the loadBalancerIP field in the `values.yaml` file, but using another field when passing the value of the loadBalancerIP to the service
- Adds an option to specify a loadBalancerIP for the Attu service (which exists in the template, but was missing in `values.yaml`)

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
