### PR TITLE
[milvus-minio]Minio pdb apiversion support

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: High Performance, Kubernetes Native Object Storage
 name: minio
-version: 8.0.16
+version: 8.0.17
 appVersion: master
 keywords:
 - storage

--- a/charts/minio/templates/_helpers.tpl
+++ b/charts/minio/templates/_helpers.tpl
@@ -32,6 +32,17 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for poddisruptionbudget.
+*/}}
+{{- define "minio.pdb.apiVersion" -}}
+{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for networkpolicy.
 */}}
 {{- define "minio.networkPolicy.apiVersion" -}}

--- a/charts/minio/templates/poddisruptionbudget.yaml
+++ b/charts/minio/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "minio.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: minio


### PR DESCRIPTION
## What this PR does / why we need it:
This pull request aims to update the Minio Pod Disruption Budget (PDB) API version from "policy/v1beta1" to "policy/v1" in version 1.25.
As of Kubernetes version 1.25, the "policy/v1beta1" API version for Pod Disruption Budget has been deprecated, and the recommended default API version is "policy/v1". 

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [x] PR only contains changes for one chart
